### PR TITLE
declared sbt.version=0.12.4 due to compatability issue with the sbt 0.13...

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.12.4


### PR DESCRIPTION
I've added build.properties file and declared sbt.version=0.12.4 due to compatibility issue with the sbt 0.13
